### PR TITLE
Corrected crash on wasm run when calling ImGui::RenderNotification()

### DIFF
--- a/unixExample/backends/ImGuiNotify.hpp
+++ b/unixExample/backends/ImGuiNotify.hpp
@@ -526,7 +526,7 @@ namespace ImGui
 			char windowName[50];
 			#ifdef _WIN32
 				sprintf_s(windowName, "##TOAST%d", (int)i);
-			#elif defined(__linux__)
+			#elif defined(__linux__) || defined(__EMSCRIPTEN__)
 				sprintf(windowName, "##TOAST%d", (int)i);
 			#else
 				throw "Unsupported platform";

--- a/win32Example/backends/ImGuiNotify.hpp
+++ b/win32Example/backends/ImGuiNotify.hpp
@@ -526,7 +526,7 @@ namespace ImGui
 			char windowName[50];
 			#ifdef _WIN32
 				sprintf_s(windowName, "##TOAST%d", (int)i);
-			#elif defined(__linux__)
+			#elif defined(__linux__) || defined(__EMSCRIPTEN__)
 				sprintf(windowName, "##TOAST%d", (int)i);
 			#else
 				throw "Unsupported platform";


### PR DESCRIPTION
Using ImGui OpenGL3 binding you can compile to wasm/webgl. Unfortunately due to the prepocessing condition on "sprinf" in ImGui::RenderNotification the wasm build was crashing because of the "throw "Unsupported platform".
