### PR TITLE
Corrected crash on macOS

### DIFF
--- a/unixExample/backends/ImGuiNotify.hpp
+++ b/unixExample/backends/ImGuiNotify.hpp
@@ -527,7 +527,9 @@ namespace ImGui
 			#ifdef _WIN32
 				sprintf_s(windowName, "##TOAST%d", (int)i);
 			#elif defined(__linux__) || defined(__EMSCRIPTEN__)
-				sprintf(windowName, "##TOAST%d", (int)i);
+				std::sprintf(windowName, "##TOAST%d", (int)i);
+			#elif defined (__APPLE__)
+				std::snprintf(windowName, 50, "##TOAST%d", (int)i);
 			#else
 				throw "Unsupported platform";
 			#endif

--- a/win32Example/backends/ImGuiNotify.hpp
+++ b/win32Example/backends/ImGuiNotify.hpp
@@ -527,7 +527,9 @@ namespace ImGui
 			#ifdef _WIN32
 				sprintf_s(windowName, "##TOAST%d", (int)i);
 			#elif defined(__linux__) || defined(__EMSCRIPTEN__)
-				sprintf(windowName, "##TOAST%d", (int)i);
+				std::sprintf(windowName, "##TOAST%d", (int)i);
+			#elif defined (__APPLE__)
+				std::snprintf(windowName, 50, "##TOAST%d", (int)i);
 			#else
 				throw "Unsupported platform";
 			#endif


### PR DESCRIPTION
I encountered an unexpected interrupt and threw "Unsupported platform" while calling ImGui::InsertNotification() on macOS, so I added support for macOS.  I replaced sprintf() with std:: snprintf() because of it has been deprecated on macOS.