### PR TITLE
MacOS Molten VK & Metal Support for Unix Cmake Example

### DIFF
--- a/unixExample/CMakeLists.txt
+++ b/unixExample/CMakeLists.txt
@@ -50,3 +50,16 @@ if(UNIX AND NOT APPLE)
 	target_link_libraries(test PRIVATE Vulkan::Vulkan)
 	target_link_libraries(test PRIVATE pthread dl X11 Xrandr)
 endif()
+
+# CMake MacOS Support for unixExample, when installing VulkanSDK choose "Global Source Headers"
+# Change unixExample/backends/IconsFontAwesome6.h appropriately as well
+
+if(APPLE)
+	find_package(Vulkan REQUIRED)
+	target_include_directories(test PRIVATE ${Vulkan_INCLUDE_DIRS})
+	target_link_libraries(test PRIVATE ${Vulkan_LIBRARIES})
+	# Linking against MoltenVK and Metal frameworks
+	find_library(MOLTEN_VK_LIBRARIES NAMES MoltenVK PATHS ${Vulkan_LIBRARY_DIRS})
+	find_library(METAL Metal)
+	target_link_libraries(test PRIVATE ${MOLTEN_VK_LIBRARIES} ${METAL})
+endif()


### PR DESCRIPTION
- Added Cmake MoltenVK and Metal support to unixExample Cmake
- Added small instruction for MacOS Cmake on option to choose when installing SDK to install in /usr/local/include/
- Examples now runs "out of the box" on MacOS (at least on Apple Silicon with VK Support)