### PR TITLE
Update for ImGui v1.91.0

### DIFF
--- a/unixExample/backends/ImGuiNotify.hpp
+++ b/unixExample/backends/ImGuiNotify.hpp
@@ -612,7 +612,7 @@ namespace ImGui
 
                     if (CalcTextSize(content).x > GetContentRegionAvail().x)
                     {
-                        scale = 0.95f;
+                        scale = 0.8f;
                     }
 
                     SetCursorPosX(GetCursorPosX() + (GetWindowSize().x - GetCursorPosX()) * scale);

--- a/unixExample/backends/ImGuiNotify.hpp
+++ b/unixExample/backends/ImGuiNotify.hpp
@@ -610,7 +610,7 @@ namespace ImGui
                     // NEEDS TO BE REWORKED
                     float scale = 0.8f;
 
-                    if (CalcTextSize(content).x > GetWindowContentRegionMax().x)
+                    if (CalcTextSize(content).x > GetContentRegionAvail().x)
                     {
                         scale = 0.95f;
                     }

--- a/win32Example/backends/ImGuiNotify.hpp
+++ b/win32Example/backends/ImGuiNotify.hpp
@@ -612,7 +612,7 @@ namespace ImGui
 
                     if (CalcTextSize(content).x > GetContentRegionAvail().x)
                     {
-                        scale = 0.95f;
+                        scale = 0.8f;
                     }
 
                     SetCursorPosX(GetCursorPosX() + (GetWindowSize().x - GetCursorPosX()) * scale);

--- a/win32Example/backends/ImGuiNotify.hpp
+++ b/win32Example/backends/ImGuiNotify.hpp
@@ -610,7 +610,7 @@ namespace ImGui
                     // NEEDS TO BE REWORKED
                     float scale = 0.8f;
 
-                    if (CalcTextSize(content).x > GetWindowContentRegionMax().x)
+                    if (CalcTextSize(content).x > GetContentRegionAvail().x)
                     {
                         scale = 0.95f;
                     }


### PR DESCRIPTION
From update of ImGui there is obsolete this function:
```cpp
 if (CalcTextSize(content).x > GetWindowContentRegionMax().x)
 ```
From the ImGui update logs:
```
- 2024/07/25 (1.91.0) - obsoleted GetContentRegionMax(), GetWindowContentRegionMin() and GetWindowContentRegionMax(). (see #7838 on GitHub for more info)
                         you should never need those functions. you can do everything with GetCursorScreenPos() and GetContentRegionAvail() in a more simple way.
                            - instead of:  GetWindowContentRegionMax().x - GetCursorPos().x
                            - you can use: GetContentRegionAvail().x
                            - instead of:  GetWindowContentRegionMax().x + GetWindowPos().x
                            - you can use: GetCursorScreenPos().x + GetContentRegionAvail().x // when called from left edge of window
                            - instead of:  GetContentRegionMax()
                            - you can use: GetContentRegionAvail() + GetCursorScreenPos() - GetWindowPos() // right edge in local coordinates
                            - instead of:  GetWindowContentRegionMax().x - GetWindowContentRegionMin().x
                            - you can use: GetContentRegionAvail() // when called from left edge of window
```

So I changed the `GetWindowContentRegionMax` to the `GetContentRegionAvail`